### PR TITLE
Forbid namespace seperator "::" in type name due to being YAML-illegal

### DIFF
--- a/spec/core/generator_spec.cr
+++ b/spec/core/generator_spec.cr
@@ -135,11 +135,11 @@ describe OpenAPI::Generator do
               type: string
               readOnly: true
             inner_schema:
-              $ref: '#/components/schemas/Model%3A%3AInnerModel'
+              $ref: '#/components/schemas/Model_InnerModel'
             cast:
               type: string
               example: "1"
-        Model::InnerModel:
+        Model_InnerModel:
           required:
           - array_of_int
           type: object
@@ -149,7 +149,7 @@ describe OpenAPI::Generator do
               items:
                 type: integer
               writeOnly: true
-        Model::ComplexModel:
+        Model_ComplexModel:
           required:
           - union_types
           - free_form
@@ -160,7 +160,7 @@ describe OpenAPI::Generator do
               oneOf:
               - type: object
                 additionalProperties:
-                  $ref: '#/components/schemas/Model%3A%3AInnerModel'
+                  $ref: '#/components/schemas/Model_InnerModel'
               - type: integer
               - type: string
             free_form:

--- a/spec/helpers/amber_spec.cr
+++ b/spec/helpers/amber_spec.cr
@@ -155,11 +155,11 @@ describe OpenAPI::Generator::Helpers::Amber do
               type: string
               readOnly: true
             inner_schema:
-              $ref: '#/components/schemas/Model%3A%3AInnerModel'
+              $ref: '#/components/schemas/Model_InnerModel'
             cast:
               type: string
               example: "1"
-        Model::InnerModel:
+        Model_InnerModel:
           required:
           - array_of_int
           type: object
@@ -169,7 +169,7 @@ describe OpenAPI::Generator::Helpers::Amber do
               items:
                 type: integer
               writeOnly: true
-        Model::ComplexModel:
+        Model_ComplexModel:
           required:
           - union_types
           - free_form
@@ -180,7 +180,7 @@ describe OpenAPI::Generator::Helpers::Amber do
               oneOf:
               - type: object
                 additionalProperties:
-                  $ref: '#/components/schemas/Model%3A%3AInnerModel'
+                  $ref: '#/components/schemas/Model_InnerModel'
               - type: integer
               - type: string
             free_form:

--- a/spec/helpers/lucky_spec.cr
+++ b/spec/helpers/lucky_spec.cr
@@ -131,11 +131,11 @@ describe OpenAPI::Generator::Helpers::Lucky do
               type: string
               readOnly: true
             inner_schema:
-              $ref: '#/components/schemas/Model%3A%3AInnerModel'
+              $ref: '#/components/schemas/Model_InnerModel'
             cast:
               type: string
               example: "1"
-        Model::InnerModel:
+        Model_InnerModel:
           required:
           - array_of_int
           type: object
@@ -145,7 +145,7 @@ describe OpenAPI::Generator::Helpers::Lucky do
               items:
                 type: integer
               writeOnly: true
-        Model::ComplexModel:
+        Model_ComplexModel:
           required:
           - union_types
           - free_form
@@ -156,7 +156,7 @@ describe OpenAPI::Generator::Helpers::Lucky do
               oneOf:
               - type: object
                 additionalProperties:
-                  $ref: '#/components/schemas/Model%3A%3AInnerModel'
+                  $ref: '#/components/schemas/Model_InnerModel'
               - type: integer
               - type: string
             free_form:

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -36,7 +36,7 @@ struct Model
         "readOnly": true
       },
       "inner_schema": {
-        "$ref": "#/components/schemas/Model%3A%3AInnerModel"
+        "$ref": "#/components/schemas/Model_InnerModel"
       },
       "cast": {
         "type": "string",
@@ -94,7 +94,7 @@ struct Model
             {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/components/schemas/Model%3A%3AInnerModel"
+                "$ref": "#/components/schemas/Model_InnerModel"
               }
             },
             {

--- a/src/openapi-generator/serializable.cr
+++ b/src/openapi-generator/serializable.cr
@@ -287,7 +287,8 @@ module OpenAPI::Generator::Serializable
     # For every registered class, we get its schema and store it in the schemas.
     schemas = Hash(String, OpenAPI::Schema | OpenAPI::Reference).new
     {% for serializable_class in SERIALIZABLE_CLASSES %}
-      schemas["{{serializable_class.id}}"] = {{serializable_class}}.generate_schema
+      # Forbid namespace seperator "::" in type name due to being YAML-illegal in plain style (YAML 1.2 - 7.3.3)
+      schemas[{{serializable_class.id.split("::").join("_")}}] = {{serializable_class}}.generate_schema
     {% end %}
     # And we return the list of schemas.
     schemas

--- a/src/openapi-generator/serializable.cr
+++ b/src/openapi-generator/serializable.cr
@@ -132,11 +132,11 @@ module OpenAPI::Generator::Serializable
           read_only: {{ read_only }},
           write_only: {{ write_only }},
           all_of: [
-            OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{extra.stringify}})}"
+            OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{extra.stringify.split("::").join("_")}})}"
           ]
         )
         {% else %}
-        %generated_schema = OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{extra.stringify}})}"
+        %generated_schema = OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{extra.stringify.split("::").join("_")}})}"
         {% end %}
       {% elsif type == "self_schema" %}
         %type = nil
@@ -189,11 +189,11 @@ module OpenAPI::Generator::Serializable
             read_only: {{ read_only }},
             write_only: {{ write_only }},
             all_of: [
-              OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{extra.stringify}})}"
+              OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{extra.stringify.split("::").join("_")}})}"
             ]
           )
           {% else %}
-          %generated_schema = OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{extra.stringify}})}"
+          %generated_schema = OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{extra.stringify.split("::").join("_")}})}"
           {% end %}
         {% elsif type == "self_schema" %}
           %type = nil
@@ -277,7 +277,7 @@ module OpenAPI::Generator::Serializable
   def to_openapi_schema
     OpenAPI::Schema.new(
       all_of: [
-        OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{@type.stringify}})}",
+        OpenAPI::Reference.new ref: "#/components/schemas/#{URI.encode_www_form({{@type.stringify.split("::").join("_")}})}",
       ]
     )
   end


### PR DESCRIPTION
- Resolves https://github.com/elbywan/openapi-generator/issues/2

- Note: the reason why the CI is [failing on this branch](https://travis-ci.com/github/place-labs/openapi-generator/jobs/493890148) is because some shard dependencies are pinned to <1.0.0 Crystal version, but the Travis running is running Crystal 1.0.0. Travis only allows Crystal to run on [either latest or nightly](https://crystal-lang.org/reference/guides/ci/travis.html#using-a-specific-crystal-release). Hence for this branch to pass the specs, or for future update before bumping the entire lib to Crystal 1.0.0, this [PR](https://github.com/elbywan/openapi-generator/pull/5) would have to be merged in first.

```bash
Unable to satisfy the following requirements:
224
225- `crystal (~> 0.26, >= 0.26.0)` required by `open_api 1.2.1+git.commit.7ad39e980ff64dfa88414ca0d2c8515159ab51ae`
226Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update is available.
227The command "shards install" failed and exited with 1 during .
```