### PR TITLE
Add Tuple serialization

### DIFF
--- a/spec/amber/helper_spec.cr
+++ b/spec/amber/helper_spec.cr
@@ -199,6 +199,7 @@ describe OpenAPI::Generator::Helpers::Amber do
           - union_types
           - free_form
           - array_of_hash
+          - tuple
           type: object
           properties:
             union_types:
@@ -219,6 +220,23 @@ describe OpenAPI::Generator::Helpers::Amber do
                   oneOf:
                   - type: integer
                   - type: string
+            tuple:
+              maxItems: 3
+              minItems: 3
+              type: array
+              items:
+                oneOf:
+                - type: integer
+                - type: string
+                - maxItems: 1
+                  minItems: 1
+                  type: array
+                  items:
+                    oneOf:
+                    - type: array
+                      items:
+                        type: number
+                    - type: boolean
         AmberSpec_Payload:
           required:
           - hello

--- a/spec/core/generator_spec.cr
+++ b/spec/core/generator_spec.cr
@@ -154,6 +154,7 @@ describe OpenAPI::Generator do
           - union_types
           - free_form
           - array_of_hash
+          - tuple
           type: object
           properties:
             union_types:
@@ -174,6 +175,23 @@ describe OpenAPI::Generator do
                   oneOf:
                   - type: integer
                   - type: string
+            tuple:
+              maxItems: 3
+              minItems: 3
+              type: array
+              items:
+                oneOf:
+                - type: integer
+                - type: string
+                - maxItems: 1
+                  minItems: 1
+                  type: array
+                  items:
+                    oneOf:
+                    - type: array
+                      items:
+                        type: number
+                    - type: boolean
       responses: {}
       parameters: {}
       examples: {}

--- a/spec/lucky/helper_spec.cr
+++ b/spec/lucky/helper_spec.cr
@@ -150,6 +150,7 @@ describe OpenAPI::Generator::Helpers::Lucky do
           - union_types
           - free_form
           - array_of_hash
+          - tuple
           type: object
           properties:
             union_types:
@@ -170,6 +171,23 @@ describe OpenAPI::Generator::Helpers::Lucky do
                   oneOf:
                   - type: integer
                   - type: string
+            tuple:
+              maxItems: 3
+              minItems: 3
+              type: array
+              items:
+                oneOf:
+                - type: integer
+                - type: string
+                - maxItems: 1
+                  minItems: 1
+                  type: array
+                  items:
+                    oneOf:
+                    - type: array
+                      items:
+                        type: number
+                    - type: boolean
         LuckySpec_Payload:
           required:
           - hello

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -79,13 +79,15 @@ struct Model
     property union_types : Int32 | String | Hash(String, InnerModel)
     property free_form : JSON::Any
     property array_of_hash : Array(Hash(String, Int32 | String))
+    property tuple : Tuple(Int32, String, Tuple(Bool | Array(Float64)))
 
     SCHEMA = <<-JSON
     {
       "required": [
         "union_types",
         "free_form",
-        "array_of_hash"
+        "array_of_hash",
+        "tuple"
       ],
       "type": "object",
       "properties": {
@@ -123,6 +125,39 @@ struct Model
                 }
               ]
             }
+          }
+        },
+        "tuple": {
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "maxItems": 1,
+                "minItems": 1,
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                }
+              }
+            ]
           }
         }
       }

--- a/spec/spider-gazelle/helper_spec.cr
+++ b/spec/spider-gazelle/helper_spec.cr
@@ -206,6 +206,7 @@ describe OpenAPI::Generator::Helpers::ActionController do
           - union_types
           - free_form
           - array_of_hash
+          - tuple
           type: object
           properties:
             union_types:
@@ -226,6 +227,23 @@ describe OpenAPI::Generator::Helpers::ActionController do
                   oneOf:
                   - type: integer
                   - type: string
+            tuple:
+              maxItems: 3
+              minItems: 3
+              type: array
+              items:
+                oneOf:
+                - type: integer
+                - type: string
+                - maxItems: 1
+                  minItems: 1
+                  type: array
+                  items:
+                    oneOf:
+                    - type: array
+                      items:
+                        type: number
+                    - type: boolean
         ActionControllerSpec_Payload:
           required:
           - mandatory

--- a/src/openapi-generator/extensions.cr
+++ b/src/openapi-generator/extensions.cr
@@ -40,7 +40,7 @@ struct Tuple
 
       ::OpenAPI::Generator::Serializable.generate_schema(
         schema_items,
-        types: {{ types}},
+        types: {{ types }},
       )
     {% end %}
 

--- a/src/openapi-generator/extensions.cr
+++ b/src/openapi-generator/extensions.cr
@@ -22,6 +22,38 @@ class Array(T)
 end
 
 # :nodoc:
+# Define a `self.to_openapi_schema` method for the Tuple class.
+#
+# OpenAPI 3.0 does not support tuples (3.1 does), so we serialize it into a fixed bounds array.
+# see: https://github.com/OAI/OpenAPI-Specification/issues/1026
+struct Tuple
+  def self.to_openapi_schema
+    schema_items = uninitialized OpenAPI::Schema | OpenAPI::Reference
+
+    {% begin %}
+      {% types = [] of Types %}
+      {% for i in 0...T.size %}
+        {% for t in T[i].union_types %}
+          {% types << t %}
+        {% end %}
+      {% end %}
+
+      ::OpenAPI::Generator::Serializable.generate_schema(
+        schema_items,
+        types: {{ types}},
+      )
+    {% end %}
+
+    OpenAPI::Schema.new(
+      type: "array",
+      items: schema_items,
+      min_items: {{ T.size }},
+      max_items: {{ T.size }}
+    )
+  end
+end
+
+# :nodoc:
 # Define a `self.to_openapi_schema` method for the Hash class.
 class Hash(K, V)
   # Returns the OpenAPI schema associated with the Hash.


### PR DESCRIPTION
### Purpose 

Adds the `self.to_openapi_schema` for the `Tuple` type.

@dukeraphaelng This should solve #9, let me know if this looks good to you I'll merge afterwards.

#### Note

OpenAPI v3.0.x does not support the proper way to express tuples as a json schema.

Passing an array of [items](https://json-schema.org/understanding-json-schema/reference/array.html) is [forbidden](https://swagger.io/specification/) by the specification: 

- *Value MUST be an object and not an array. Inline or referenced schema MUST be of a Schema Object and not a standard JSON Schema. items MUST be present if the type is array.*).
- *Related issue: https://github.com/OAI/OpenAPI-Specification/issues/1026.*
- *Support has been recently added with the release of OpenAPI 3.1., but this is beyond the scope of this PR.*

**As a workaround this PR serializes tuples into an array with fixed bounds and items that can be one of the tuple types.**

#### Example

```crystal
puts Tuple(Int32, String, Tuple(Bool | Array(Float64))).to_openapi_schema.to_pretty_json
```

```json
{
  "maxItems": 3,
  "minItems": 3,
  "type": "array",
  "items": {
    "oneOf": [
      {
        "type": "integer"
      },
      {
        "type": "string"
      },
      {
        "maxItems": 1,
        "minItems": 1,
        "type": "array",
        "items": {
          "oneOf": [
            {
              "type": "array",
              "items": {
                "type": "number"
              }
            },
            {
              "type": "boolean"
            }
          ]
        }
      }
    ]
  }
}
```