### PR TITLE
Fix illegal empty array in NamedTuple

### DIFF
--- a/src/openapi-generator/extensions.cr
+++ b/src/openapi-generator/extensions.cr
@@ -98,6 +98,10 @@ struct NamedTuple
       {% end %}
     {% end %}
 
+    if schema.required.try &.empty?
+      schema.required = nil
+    end
+
     schema
   end
 end


### PR DESCRIPTION
This issue https://github.com/elbywan/openapi-generator/issues/16 resolved here https://github.com/elbywan/openapi-generator/commit/8c79067e0c58ef6a956c986eb8dc0b162e4cd4fb was not fixed for NamedTuple. This PR will fix this.